### PR TITLE
Unlock codefog/contao-news_categories 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "conflict": {
         "contao/news-bundle": "<4.4 || ^6.0",
         "contao/calendar-bundle": "<4.4 || ^6.0",
-        "codefog/contao-news_categories": "^4.0"
+        "codefog/contao-news_categories": "^5.0"
     },
     "suggest": {
         "codefog/contao-news_categories": "Allows sibling pagination limited by categories"

--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,6 @@
     "require-dev": {
          "contao/manager-plugin": "^2.0"
     },
-    "conflict": {
-        "contao/news-bundle": "<4.4 || ^6.0",
-        "contao/calendar-bundle": "<4.4 || ^6.0",
-        "codefog/contao-news_categories": "^5.0"
-    },
     "suggest": {
         "codefog/contao-news_categories": "Allows sibling pagination limited by categories"
     },

--- a/src/Module/SiblingNavigationNews.php
+++ b/src/Module/SiblingNavigationNews.php
@@ -22,7 +22,16 @@ use Contao\News;
 use Contao\NewsModel;
 use Contao\StringUtil;
 use Contao\System;
-use Haste\Model\Model as HasteModel;
+
+if (class_exists(\Haste\Model\Model::class)) {
+    class HasteModel extends \Haste\Model\Model
+    {
+    }
+} else if (class_exists(\Codefog\HasteBundle\Model\DcaRelationsModel::class)){
+    class HasteModel extends \Codefog\HasteBundle\Model\DcaRelationsModel
+    {
+    }
+}
 
 class SiblingNavigationNews extends ModuleNews
 {


### PR DESCRIPTION
This PR unlocks codefog/contao-news_categories 4.x and fixes an error when using codefog/contao-haste 5.0 which is required for codefog/contao-news_categories 4.x. 
This change is still compatible with codefog/contao-news_categories 3.x and Haste 4.x.